### PR TITLE
Add doc comments to tls config struct

### DIFF
--- a/docs/template.mdx
+++ b/docs/template.mdx
@@ -1,0 +1,312 @@
+---
+id: agentConfigReference
+slug: /docs/elasticagent/configreference
+title: Elastic Agent configuraton reference
+description: Reference documentation and examples about Elastic Agent configuration settings.
+date: 2022-03-14
+tags: ['Elastic Agent','Settings','configuration','elastic-agent.yml']
+---
+
+## Agent
+
+Defines the Elastic Agent configuration.
+
+```yaml
+outputs: #...
+inputs: #...
+mode: #...
+```
+---
+
+`outputs` _<DocLink id="agentConfigReference" section="output" text="map[string]Output" />_
+
+: One or more output configurations that specify where to send data.
+You can pair specific inputs with specific outputs.
+
+---
+
+`inputs` _<DocLink id="agentConfigReference" section="input" text="[]Input" />_
+
+: List of input configurations that specify how to locate and processes data.
+By default Elastic Agent collects system metrics, such as cpu, memory, network, and filesystem metrics, and sends them to the default output. 
+
+---
+
+`mode` _string_
+
+: The managementment mode for Elastic Agent.
+
+    Valid values:
+
+    - `local` (default)
+    - `whatelse`
+
+{/* Not sure how tricky this is ^^, but where we provide a list of valid values, would be good to indicate the default in the list itself. */}
+
+{/* There is only one valid value shown in the example. Is the other value `fleet`? */}
+
+---
+
+## Output
+
+{/* I'm not sure what the best way of doing this is */}
+
+Defines an Elastic Agent output configuration. Can be an elasticsearch or
+logstash output configuration.
+
+{/* Would be nice to have links here, but as you can see, our syntax is kind of verbose. Not sure we want to embed this in comments. */}
+
+## Elasticsearch
+
+Defines an Elasticsearch output configuration.
+
+```yaml
+default:
+  type: elasticsearch
+  hosts: [127.0.0.1:9200]
+  api-key: "example-key"
+  # username: "elastic"
+  # password: "changeme"
+```
+
+---
+
+`hosts` _[]string_
+
+: A list of Elasticsearch nodes to connect to.
+The events are distributed to these nodes in round robin order.
+If one node becomes unreachable, the event is automatically sent to another node.	
+
+---
+
+`api-key` _string_
+
+: The API key to use for token-based authentication.
+
+---
+
+`username` _string_
+
+: The basic authentication username for connecting to Elasticsearch.
+
+---
+
+`password` _string_
+
+: The basic authentication password for connecting to Elasticsearch.
+
+---
+
+## Input
+
+Defines an Elastic Agent input configuration.
+
+## Config
+
+{/* The struct name is Config, but I think we need something more descriptive. Maybe Filestream input Can we automate this?  */}
+
+Defines a filestream input configuration.
+
+---
+
+`id` _string_
+
+: The ID of blah blah blah
+
+---
+
+`data_stream` _<DocLink id="agentConfigReference" section="datastream" text="typ.DataStream" />_
+
+: The data stream to send events to.
+
+---
+
+`paths` _[]string_
+
+: A list of glob-based paths that will be crawled and fetched.
+
+---
+
+`use_output` _string_
+
+: The output to use for this filestream output.
+
+---
+
+## Datastream
+
+Defines the datastream used by an input.
+
+---
+
+{/* I think this is wrong, but I'm not sure how the struct maps to what I see in the refernece yaml.  */}
+
+`type` _string_
+
+: The type of blah blah blah.
+
+---
+
+{/* How will we document available datasets? It's gonna be A LOT. */}
+
+`dataset` _string_
+
+: The dataset to use to fetch and structure data.
+The dataset name must conform to the naming conventions for Elasticsearch indices.
+The name cannot contain dashes (-) or exceed 100 bytes.
+
+---
+
+`namespace` _string_
+
+: A user-configurable arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit.
+A namespace can be up to 100 bytes in length (multibyte characters will count toward this limit faster).
+
+## Config
+
+{/* Again the struct name is Config, but I think we need something more descriptive. Maybe something like TCP input. Can we automate this?  */}
+
+Defines a tcp input configuration.
+
+---
+
+`port` _int_
+
+: The TCP port to listen on for event streams.
+
+---
+
+`host` _string_
+
+: The host to listen on for event streams.
+
+---
+
+`ssl` _<DocLink id="agentConfigReference" section="tlsconfig" text="typ.TLSConfig" />_
+
+## TLSConfig
+
+Configure a TCP client or server.
+
+```yaml
+ssl.verification_mode: full
+ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+ssl.cipher_suites: []
+ssl.curve_types: []
+```
+
+`supported_protocols` _[]string_
+
+: List of allowed SSL/TLS versions.
+If the SSL/TLS server supports none of the specified versions, the connection will be dropped during or after the handshake.
+
+    Valid values:
+
+    - `SSLv3`
+    - `TLSv1`
+    - `TLSv1.0`
+    - `TLSv1.1`
+    - `TLSv1.2`
+    - `TLSv1.3`
+
+---
+
+`verification_mode` _string_
+
+: Configures the SSL/TLS verification mode used during handshake.
+
+    Valid values:
+
+    - `full` (default)
+    - `strict`
+    - `certificate`
+    - `none`
+
+---
+
+`certificates` _[]string_
+
+: List of certificate chains to present to the other side of the connection.
+
+---
+
+`certificate_authorities` _[]string_
+
+: List of root certificate authorities used to verify server certificates.
+If this setting is empty or unset, TLS may use the system's root CA (not supported on MS Windows).
+
+---
+
+`client_certificate_authorities` _[]string_
+
+: List of root certificate authorities to use to verify client certificates.
+If this setting is empty or unset, TLS may use the system's root CA set (not supported on MS Windows).
+
+---
+
+`cipher_suites` _[]string_
+
+: List of supported cipher suites.
+If nil, a default list provided by the implementation is used.
+
+    For a list of supported cipher suites, see ADD LINK HERE 
+
+---
+
+`curve_types` _[]string_
+
+: List of elliptic curve types to use in an ECDHE handshake.
+If empty, the implementation chooses a default.
+
+    Valid values:
+
+    - `P-256`
+    - `P-384`
+    - `P-521`
+    - `X25519`
+
+---
+
+`renegotiation` _string_
+
+: The type of renegotiation that's supported.
+The default is correct for the vast majority of applications.
+
+    Valid values:
+
+    - `never` (default)
+    - `once`
+    - `freely`
+
+---
+
+`verification_mode` _string_
+
+: Controls how certificates from the client are verified.
+Does not affect the TCP client.
+
+    Valid values:
+
+    - `none`
+    - `optional`
+    - `required` (default)
+
+---
+
+`ca_sha256` _string_
+
+: The CA certificate pin used to validate the CA used to trust the server certificate.
+The pin is a base64 encoded string of the SHA-256 of the certificate.
+
+    <DocCallOut color="warning" title="Important">
+      Do not use this setting with `verification_mode: none`, or the check will always fail because it will not receive any verified chains.
+    </DocCallOut>
+
+----
+
+`ca_trusted _fingerprint` _string_
+
+: The HEX-encoded fingerprint of a CA certificate.
+If present in the chain, this certificate is added to the list of trusted CAs (root CAs) during the handshake.
+
+---

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -1,22 +1,61 @@
 package agent
 
+// Defines the Elastic Agent configuration.
+// QUESTION: I'm worried that users will confuse this with settings under "agent."
+// like agent.logging.
 type Agent struct {
-	Outputs        map[string]Output
-	Inputs         []Input
-	ManagementMode string
+
+	//   description: |
+	//     One or more output configurations that specify where to send data.
+	//     You can pair specific inputs with specific outputs.
+	Outputs        map[string]Output `yaml:"outputs"`
+
+	//   description: |
+	//     List of input configurations that specify how to locate and processes data.
+	//     By default Elastic Agent collects system metrics, such as cpu, memory, network, and filesystem metrics, and sends them to the default output. 
+	Inputs         []Input `yaml:"inputs"`
+
+	//   description: |
+	//     The management mode.
+	//   values:
+	//     - local
+	//     - whatelse
+	//   default: local
+	ManagementMode string `yaml:"mode"`
 }
 
-type Output struct {
+// Defines an Elastic Agent output configuration.
+// Can be an Elasticsearch or Logstash output configuration.
+type Output struct { `yaml:"type"`
 	Type string
 }
 
+// Defines the Elasticsearch output configuration.
+//
 type Elasticsearch struct {
-	Hosts    []string
-	ApiKey   string
-	Username string
-	Password string
+
+	//   description: |
+	//     A list of Elasticsearch nodes to connect to.
+	//     The events are distributed to these nodes in round robin order.
+	//     If one node becomes unreachable, the event is automatically sent to another node.	
+	Hosts    []string `yaml:"hosts"`
+
+
+	//   description: |
+	//     The API key to use for token-based authentication.
+	ApiKey   string `yaml:"api-key"`
+
+	//   description: |
+	//     The basic authentication username for connecting to Elasticsearch.
+	Username string `yaml:"username"`
+
+	//   description: |
+	//     The basic authentication password for connecting to Elasticsearch.
+	Password string `yaml:"password"`
 }
 
+// Defines an Elastic Agent input configuration.
+//
 type Input struct {
 	Id string
 }

--- a/pkg/input/filestream/config.go
+++ b/pkg/input/filestream/config.go
@@ -2,9 +2,22 @@ package filestream
 
 import "github.com/ph/doc-experiment/pkg/typ"
 
-type Config struct {
-	Id         string
-	DataStream typ.DataStream
-	Paths      []string
-	UseOutput  string
+// Defines a filestream input configuration.
+type Config struct { `yaml:"???"`
+	
+	//   description: |
+	//     The ID of blah blah blah.
+	Id         string `yaml:"id"`
+
+	//   description: |
+	//     The data stream to send events to.
+	DataStream typ.DataStream `yaml:"data_stream"`
+	
+	//   description: |
+	//     A list of glob-based paths that will be crawled and fetched.
+	Paths      []string `yaml:"paths"`
+
+	//   description: |
+	//     The output to use for this filestream output.
+	UseOutput  string `yaml:"use_output"`
 }

--- a/pkg/input/tcp/config.go
+++ b/pkg/input/tcp/config.go
@@ -2,8 +2,18 @@ package tcp
 
 import "github.com/ph/doc-experiment/pkg/typ"
 
+// Defines a tcp input configuration
 type Config struct {
-	Port int
-	Host string
-	TLS  typ.TLSConfig
+	
+	//   description: |
+	//     The TCP port to listen on for event streams.
+	Port int `yaml:"port"`
+
+	//   description: |
+	//     The host to listen on for event streams.
+	Host string `yaml:"host"`
+
+	//   description: |
+	//     Configuration options for SSL parameters like the certificate, key, and the certificate authorities to use.
+	TLS  typ.TLSConfig `yaml:"ssl"`
 }

--- a/pkg/typ/data_stream.go
+++ b/pkg/typ/data_stream.go
@@ -1,7 +1,21 @@
 package typ
 
+// Defines the datastream used by an input.
+//
 type DataStream struct {
-	Type      string
-	DataSet   string
-	Namespace string
+	
+	//   description: |
+	//     The type of blah blah blah.
+	Type      string `yaml:"type"`
+	
+	//   description: |
+	//     The dataset to use to fetch and structure data.
+	//     The dataset name must conform to the naming conventions for Elasticsearch indices.
+	//     The name cannot contain dashes (-) or exceed 100 bytes.
+	DataSet   string `yaml:"dataset"`
+	
+	//   description: |
+	//     A user-configurable arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit.
+	//     A namespace can be up to 100 bytes in length (multibyte characters will count toward this limit faster).
+	Namespace string `yaml:"namespace"`
 }

--- a/pkg/typ/tls_config.go
+++ b/pkg/typ/tls_config.go
@@ -7,52 +7,95 @@ import (
 )
 
 // TLSConfig is the interface used to configure a tcp client or server from a `Config`
+//
+//  examples:
+//     - value: tlsConfigExample
 type TLSConfig struct {
 
-	// List of allowed SSL/TLS protocol versions. Connections might be dropped
-	// after handshake succeeded, if TLS version in use is not listed.
-	Versions []TLSVersion
+	//   description: |
+	//     List of allowed SSL/TLS versions.
+	//     If the SSL/TLS server supports none of the specified versions, the connection will be dropped during or after the handshake.
+	//   values:
+	//     - SSLv3
+	//     - TLSv1
+	//     - TLSv1.0
+	//     - TLSv1.1
+	//     - TLSv1.2
+	//     - TLSv1.3
+	//   default: [TLSv1.1, TLSv1.2, TLSv1.3]
+	Versions []TLSVersion `yaml:"supported_protocols"`
 
-	// Configure SSL/TLS verification mode used during handshake. By default
-	// VerifyFull will be used.
-	Verification TLSVerificationMode
+	//   description: |
+	//     Configures the SSL/TLS verification mode used during handshake.
+	//   values:
+	//     - full
+	//     - strict
+	//     - certificate
+	//     - none
+	//   default: full
+	Verification TLSVerificationMode `yaml:"verification_mode"`
 
-	// List of certificate chains to present to the other side of the
-	// connection.
-	Certificates []tls.Certificate
+	//   description: |
+	//     List of certificate chains to present to the other side of the connection.
+	Certificates []tls.Certificate `yaml:"certificates"`
 
-	// Set of root certificate authorities use to verify server certificates.
-	// If RootCAs is nil, TLS might use the system its root CA set (not supported
-	// on MS Windows).
-	RootCAs *x509.CertPool
+	//   description: |
+	//     List of root certificate authorities used to verify server certificates.
+	//     If this setting is empty or unset, TLS may use the system's root CA (not supported on MS Windows).
+	RootCAs *x509.CertPool `yaml:"certificate_authorities"`
 
-	// Set of root certificate authorities use to verify client certificates.
-	// If ClientCAs is nil, TLS might use the system its root CA set (not supported
-	// on MS Windows).
-	ClientCAs *x509.CertPool
+	//   description: |
+	//     List of root certificate authorities to use to verify client certificates.
+	//     If this setting is empty or unset, TLS may use the system's root CA set (not supported on MS Windows).
+	ClientCAs *x509.CertPool `yaml:"client_certificate_authorities"` //I made this name up
 
-	// List of supported cipher suites. If nil, a default list provided by the
-	// implementation will be used.
-	CipherSuites []CipherSuite
+	//   description: |
+	//     List of supported cipher suites.
+	//     If nil, a default list provided by the implementation is used.
+	//
+	//     For a list of supported cipher suites, see https://path/to/docs/topic.html 
+	CipherSuites []CipherSuite `yaml:"cipher_suites"` // Note sure about valid values here.
 
-	// Types of elliptic curves that will be used in an ECDHE handshake. If empty,
-	// the implementation will choose a default.
-	CurvePreferences []tls.CurveID
+	//   description: |
+	//     List of elliptic curve types to use in an ECDHE handshake.
+	//     If empty, the implementation chooses a default.
+	//   values:
+	//     - P-256
+	//     - P-384
+	//     - P-521
+	//     - X25519
+	CurvePreferences []tls.CurveID `yaml:"curve_types"`
 
-	// Renegotiation controls what types of renegotiation are supported.
-	// The default, never, is correct for the vast majority of applications.
-	Renegotiation tls.RenegotiationSupport
+	//   description: |
+	//     The type of renegotiation that's supported.
+	//     The default is correct for the vast majority of applications.
+	//   values:
+	//     - never
+	//     - once
+	//     - freely
+	//   default: never
+	Renegotiation tls.RenegotiationSupport `yaml:"renegotiation"`
 
-	// ClientAuth controls how we want to verify certificate from a client, `none`, `optional` and
-	// `required`, default to required. Do not affect TCP client.
-	ClientAuth tls.ClientAuthType
+	//   description: |
+	//     Controls how certificates from the client are verified.
+	//     Does not affect the TCP client.
+	//   values:
+	//     - none
+	//     - optional
+	//     - required
+	//   default: required
+	ClientAuth tls.ClientAuthType `yaml:"ca_sha256"`
 
-	// CASha256 is the CA certificate pin, this is used to validate the CA that will be used to trust
-	// the server certificate.
-	CASha256 []string
+	//   description: |
+	//     The CA certificate pin used to validate the CA used to trust the server certificate.
+	//     The pin is a base64 encoded string of the SHA-256 of the certificate.
+	//
+	//     > Note: Do not use this setting with `verification_mode` set to `none`, or the check will always fail because it will not receive any verified chains.
+	CASha256 []string `yaml:"ca_trusted _fingerprint"`
 
-	// CATrustedFingerprint is the HEX encoded fingerprint of a CA certificate. If present in the chain
-	// this certificate will be added to the list of trusted CAs (RootCAs) during the handshake.
+	//   description: |
+	//     The HEX-encoded fingerprint of a CA certificate.
+	//     If present in the chain, this certificate is added to the list of trusted CAs (root CAs) during the handshake.
 	CATrustedFingerprint string
 
 	// time returns the current time as the number of seconds since the epoch.

--- a/pkg/typ/tls_config.go
+++ b/pkg/typ/tls_config.go
@@ -84,19 +84,19 @@ type TLSConfig struct {
 	//     - optional
 	//     - required
 	//   default: required
-	ClientAuth tls.ClientAuthType `yaml:"ca_sha256"`
+	ClientAuth tls.ClientAuthType `yaml:"verification_mode"`
 
 	//   description: |
 	//     The CA certificate pin used to validate the CA used to trust the server certificate.
 	//     The pin is a base64 encoded string of the SHA-256 of the certificate.
 	//
 	//     > Note: Do not use this setting with `verification_mode` set to `none`, or the check will always fail because it will not receive any verified chains.
-	CASha256 []string `yaml:"ca_trusted _fingerprint"`
+	CASha256 []string `yaml:"ca_sha256"`
 
 	//   description: |
 	//     The HEX-encoded fingerprint of a CA certificate.
 	//     If present in the chain, this certificate is added to the list of trusted CAs (root CAs) during the handshake.
-	CATrustedFingerprint string
+	CATrustedFingerprint string `yaml:"ca_trusted _fingerprint"`
 
 	// time returns the current time as the number of seconds since the epoch.
 	// If time is nil, TLS uses time.Now.

--- a/pkg/typ/tls_config.go
+++ b/pkg/typ/tls_config.go
@@ -8,8 +8,6 @@ import (
 
 // TLSConfig is the interface used to configure a tcp client or server from a `Config`
 //
-//  examples:
-//     - value: tlsConfigExample
 type TLSConfig struct {
 
 	//   description: |


### PR DESCRIPTION
@ph OK, so here's a first pass at adding some doc comments. This simple exercise provoked some thoughts and questions. I'll add them here to capture my thoughts.

I didn’t add any example structs because I ran out of steam and figured you would want to add those.

I added the `yaml: ...` but not sure if what I did it right.

I'll work on the markdown (mdx) template tomorrow. I have to get some questions answered before proceeding.

Let me know if there is anything else you want me to do, like add doc comments to other files.

## My to-do list

- [x] Add comments to struct (let me know if this is good enough)
- [ ] Create mdx file that shows target markdown
- [ ] Define data required for intermediary file (JSON/YAML/whatever) -- I've added some ideas below

## Comment format

Here are few conventions followed in the talos example. I've used them in my comments, but we should discuss whether they are right for us:

- Tab before //.
- 3 spaces after //.
- Each sentence on its own line.
- Description is required

The talos example didn't have empty lines, but I've added them assuming it's Ok.

## Open questions

- When, if ever, do strings need to be quoted in the doc comments?
- Do we want to include a `name` key for future use (to support languages other than Go where name can't be derived programmatically)? What about a `type` key (same reason)?
- What types are valid? Integer, Float, Boolean, String, Null, Timestamp, List?
- In the talos example, there are no descriptions for lists of `values`. We have some settings where we will (I think) want to describe the values in detail. For example, in a topic like verification mode: https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html, there are detailed descriptions.  I think we can still provide extended topics that describe how to use a bunch of settings together, but it would be better to have all the reference info in one place.
- What's the best way to handle doc links assuming they need to be versioned?

## Data we need in the intermediary file (YAML, JSON, whatever)

I think we need these keys/values starting out:

Key | Description | Required?
-- | -- | --
id* | Anchor ID | Y
name* | Setting name | Y
description | Description of the setting. May include multiple lines and markdown sections. | Y
shortdesc* | First sentence of the long description to be used in UI text strings and overview tables | Y
values | List of valid values | N
type* | Data type of the setting | Y
default | Default value of the setting | N
example | Name and reference to example | N

*We should be able to derive these programmatically (for Go programs)

We might need to add these keys/values later on to support other teams:

Key | Description
-- | -- 
cloud | Indicates whether the setting is available on ESS (true or false). Note that the cloud team already has a JSON file that identifies which user settings are supported on Cloud.
platform | Specifies a list of platforms on which the setting is supported.
setting-type | The type of Elastic setting (static or dynamic)
secure | Specifies that the setting is stored in the keystore (true or false)
stack-version | Specifies stack version when the setting was added
deprecated | Specifies if the field is deprecated (true or false)


